### PR TITLE
Only clip gothic window if settings window is hidden. 

### DIFF
--- a/D3D11Engine/BaseGraphicsEngine.h
+++ b/D3D11Engine/BaseGraphicsEngine.h
@@ -63,7 +63,8 @@ class BaseGraphicsEngine {
 public:
     enum EUIEvent {
         UI_OpenSettings,
-        UI_OpenEditor
+        UI_OpenEditor,
+        UI_ClosedSettings,
     };
 
     BaseGraphicsEngine() { };

--- a/D3D11Engine/D2DSettingsDialog.cpp
+++ b/D3D11Engine/D2DSettingsDialog.cpp
@@ -718,4 +718,7 @@ void D2DSettingsDialog::SetHidden( bool hidden ) {
 		OnOpenedSettings(); // Changed visibility from hidden to non-hidden
 
 	D2DDialog::SetHidden( hidden );
+    if ( hidden ) {
+        Engine::GraphicsEngine->OnUIEvent( BaseGraphicsEngine::EUIEvent::UI_ClosedSettings );
+    }
 }

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -5503,6 +5503,7 @@ void D3D11GraphicsEngine::OnUIEvent( EUIEvent uiEvent ) {
             Engine::GAPI->SetEnableGothicInput(
                 UIView->GetSettingsDialog()->IsHidden() );
         }
+        UpdateClipCursor( OutputWindow );
     } else if ( uiEvent == UI_ClosedSettings ) {
         // Settings can be closed in multiple ways
         UpdateClipCursor( OutputWindow );

--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -5277,7 +5277,9 @@ void D3D11GraphicsEngine::UpdateClipCursor( HWND hWnd )
 {
     RECT rect;
     static RECT last_clipped_rect;
-    if ( m_isWindowActive ) {
+ 
+    // People use open settings window to navigate to other screens
+    if ( m_isWindowActive && !HasSettingsWindow() ) {
         GetClientRect( hWnd, &rect );
         ClientToScreen( hWnd, reinterpret_cast<LPPOINT>(&rect) + 0 );
         ClientToScreen( hWnd, reinterpret_cast<LPPOINT>(&rect) + 1 );
@@ -5501,7 +5503,11 @@ void D3D11GraphicsEngine::OnUIEvent( EUIEvent uiEvent ) {
             Engine::GAPI->SetEnableGothicInput(
                 UIView->GetSettingsDialog()->IsHidden() );
         }
-    } else if ( uiEvent == UI_OpenEditor ) {
+    } else if ( uiEvent == UI_ClosedSettings ) {
+        // Settings can be closed in multiple ways
+        UpdateClipCursor( OutputWindow );
+    }
+    else if ( uiEvent == UI_OpenEditor ) {
         if ( UIView ) {
             // Show settings
             Engine::GAPI->GetRendererState().RendererSettings.EnableEditorPanel =


### PR DESCRIPTION
This PR allows users to move the mouse freely if they open the settings window.

E.g. to manage Chat while streaming, taking screenshots with snipping tools, ...
Previously users had to ALT+TAB out, which is sometimes bad, as gothic uses TAB to close inventory or opened maps etc.

- Added event for notification of settings window being closed `SetHidden(true)` as that can happen in two ways (pressing F11 again or pressing close button)
- when Settings window is opened/closed the cursor clipping will be updated
- cursor no longer clips if settings window is shown