### PR TITLE
Provides an unique meshlib for each npc

### DIFF
--- a/D3D11Engine/GothicAPI.h
+++ b/D3D11Engine/GothicAPI.h
@@ -659,6 +659,7 @@ public:
 
     /** Loads the data out of a zCModel and stores it in the cache */
     SkeletalMeshVisualInfo* LoadzCModelData( zCModel* model );
+    SkeletalMeshVisualInfo* LoadzCModelData( oCNPC* npc );
 
     /** Prints a message to the screen for the given amount of time */
     void PrintMessageTimed( const INT2& position, const std::string& strMessage, float time = 3000.0f, DWORD color = 0xFFFFFFFF );
@@ -752,6 +753,7 @@ private:
 
     /** Map for skeletal mesh visuals */
     std::unordered_map<std::string, SkeletalMeshVisualInfo*> SkeletalMeshVisuals;
+    std::unordered_map<oCNPC*, SkeletalMeshVisualInfo*> SkeletalMeshNpcs;
 
     /** Set of all vobs we registered by now */
     std::unordered_set<zCVob*> RegisteredVobs;

--- a/D3D11Engine/GothicMemoryLocations1_08k.h
+++ b/D3D11Engine/GothicMemoryLocations1_08k.h
@@ -518,6 +518,7 @@ struct GothicMemoryLocations {
     struct zCModel {
         static const unsigned int RenderNodeList = 0x0055FA50;
         static const unsigned int UpdateAttachedVobs = 0x005667F0;
+        static const unsigned int Offset_HomeVob = 0x54;
         static const unsigned int Offset_ModelProtoList = 0x58;
         static const unsigned int Offset_NodeList = 0x64;
         static const unsigned int Offset_MeshSoftSkinList = 0x70;

--- a/D3D11Engine/GothicMemoryLocations1_12f.h
+++ b/D3D11Engine/GothicMemoryLocations1_12f.h
@@ -496,6 +496,7 @@ struct GothicMemoryLocations {
     struct zCModel {
         static const unsigned int RenderNodeList = 0x00577E70;
         static const unsigned int UpdateAttachedVobs = 0x0057F330;
+        static const unsigned int Offset_HomeVob = 0x54;
         static const unsigned int Offset_ModelProtoList = 0x58;
         static const unsigned int Offset_NodeList = 0x64;
         static const unsigned int Offset_MeshSoftSkinList = 0x70;

--- a/D3D11Engine/GothicMemoryLocations2_6_fix.h
+++ b/D3D11Engine/GothicMemoryLocations2_6_fix.h
@@ -364,6 +364,7 @@ struct GothicMemoryLocations {
     struct zCModel {
         static const unsigned int RenderNodeList = 0x00579560;
         static const unsigned int UpdateAttachedVobs = 0x00580900;
+        static const unsigned int Offset_HomeVob = 0x60;
         static const unsigned int Offset_ModelProtoList = 0x64;
         static const unsigned int Offset_NodeList = 0x70;
         static const unsigned int Offset_MeshSoftSkinList = 0x7C;

--- a/D3D11Engine/GothicMemoryLocations2_6_fix_Spacer.h
+++ b/D3D11Engine/GothicMemoryLocations2_6_fix_Spacer.h
@@ -262,6 +262,7 @@ struct GothicMemoryLocations {
     struct zCModel {
         static const unsigned int RenderNodeList = 0x00704840;
         static const unsigned int UpdateAttachedVobs = 0x0070BBE0;
+        static const unsigned int Offset_HomeVob = 0x60;
         static const unsigned int Offset_ModelProtoList = 0x64;
         static const unsigned int Offset_NodeList = 0x70;
         static const unsigned int Offset_MeshSoftSkinList = 0x7C;

--- a/D3D11Engine/WorldObjects.h
+++ b/D3D11Engine/WorldObjects.h
@@ -299,6 +299,19 @@ struct SkeletalMeshVisualInfo : public BaseVisualInfo {
         }
     }
 
+    void ClearMeshes() {
+        for ( auto& [k, meshes] : SkeletalMeshes )
+            for ( SkeletalMeshInfo* smi : meshes )
+                delete smi;
+
+        for ( auto& [k, meshes] : Meshes )
+            for ( MeshInfo* mi : meshes )
+                delete mi;
+
+        SkeletalMeshes.clear();
+        Meshes.clear();
+    }
+
 #if ENABLE_TESSELATION > 0
     /** Creates PNAEN-Info for all meshes if not already there */
     void CreatePNAENInfo( bool softNormals = false );

--- a/D3D11Engine/zCModel.h
+++ b/D3D11Engine/zCModel.h
@@ -333,6 +333,10 @@ public:
         return str;
     }
 
+    zCVob* GetHomeVob() {
+        return reinterpret_cast<zCVob*>(THISPTR_OFFSET( GothicMemoryLocations::zCModel::Offset_HomeVob ));
+    }
+
 private:
 
 };


### PR DESCRIPTION
The base gd3d11 logic does not allow to use different softskin meshes, because of that they are mixed up and break down:
<details>
<summary>No fix</summary>

![fix0](https://user-images.githubusercontent.com/55413597/224817865-1947cb84-4fd7-432e-b406-7ae97363f352.jpg)
</details>

The patch separates all model infos by NPCs (like as the original gd3d11 logic by visual names) => each character can have their own sets of bodies:
<details>
<summary>Fix</summary>

![fix1](https://user-images.githubusercontent.com/55413597/224817885-529cf33d-5f75-4dbb-9820-998e9cb4f316.jpg)
![fix2](https://user-images.githubusercontent.com/55413597/224817891-6e7006d9-bb84-48d0-94c1-8221e83c9ea5.jpg)
</details>