### PR TITLE
Change pixel format from RGBA8888 to BGRA8888

### DIFF
--- a/D3D11Engine/D3D11GraphicsEngine.cpp
+++ b/D3D11Engine/D3D11GraphicsEngine.cpp
@@ -447,7 +447,7 @@ XRESULT D3D11GraphicsEngine::Init() {
     // Create dummy rendertarget for shadowcubes
     DummyShadowCubemapTexture = std::make_unique<RenderToTextureBuffer>(
         GetDevice(), POINTLIGHT_SHADOWMAP_SIZE, POINTLIGHT_SHADOWMAP_SIZE,
-        DXGI_FORMAT_R8G8B8A8_UNORM, nullptr, DXGI_FORMAT_UNKNOWN,
+        DXGI_FORMAT_B8G8R8A8_UNORM, nullptr, DXGI_FORMAT_UNKNOWN,
         DXGI_FORMAT_UNKNOWN, 1, 6 );
 
     SteamOverlay::Init();
@@ -870,7 +870,7 @@ XRESULT D3D11GraphicsEngine::OnResize( INT2 newSize ) {
         GetDevice().Get(), Resolution.x, Resolution.y, DXGI_FORMAT_R16G16B16A16_FLOAT );
 
     GBuffer0_Diffuse = std::make_unique<RenderToTextureBuffer>(
-        GetDevice().Get(), Resolution.x, Resolution.y, DXGI_FORMAT_R8G8B8A8_UNORM );
+        GetDevice().Get(), Resolution.x, Resolution.y, DXGI_FORMAT_B8G8R8A8_UNORM );
 
     HDRBackBuffer = std::make_unique<RenderToTextureBuffer>( GetDevice().Get(), Resolution.x, Resolution.y,
         (Engine::GAPI->GetRendererState().RendererSettings.CompressBackBuffer ? DXGI_FORMAT_R11G11B10_FLOAT : DXGI_FORMAT_R16G16B16A16_FLOAT) );
@@ -1129,14 +1129,14 @@ XRESULT D3D11GraphicsEngine::FetchDisplayModeListDXGI() {
     }
 
     UINT numModes = 0;
-    hr = output->GetDisplayModeList1( DXGI_FORMAT_R8G8B8A8_UNORM, 0, &numModes, nullptr );
+    hr = output->GetDisplayModeList1( DXGI_FORMAT_B8G8R8A8_UNORM, 0, &numModes, nullptr );
     if ( FAILED( hr ) || numModes == 0 ) {
         CachedDisplayModes.emplace_back( Resolution.x, Resolution.y );
         return XR_FAILED;
     }
 
     std::unique_ptr<DXGI_MODE_DESC1[]> displayModes = std::make_unique<DXGI_MODE_DESC1[]>( numModes );
-    hr = output->GetDisplayModeList1( DXGI_FORMAT_R8G8B8A8_UNORM, 0, &numModes, displayModes.get() );
+    hr = output->GetDisplayModeList1( DXGI_FORMAT_B8G8R8A8_UNORM, 0, &numModes, displayModes.get() );
     if ( FAILED( hr ) ) {
         CachedDisplayModes.emplace_back( Resolution.x, Resolution.y );
         return XR_FAILED;
@@ -5497,7 +5497,7 @@ void D3D11GraphicsEngine::GetBackbufferData( byte** data, int& pixelsize ) {
 
     // Buffer for scaling down the image
     auto rt = std::make_unique<RenderToTextureBuffer>(
-        GetDevice().Get(), width, width, DXGI_FORMAT_R8G8B8A8_UNORM );
+        GetDevice().Get(), width, width, DXGI_FORMAT_B8G8R8A8_UNORM );
 
     // Downscale to 256x256
     PfxRenderer->CopyTextureToRTV( HDRBackBuffer->GetShaderResView(), rt->GetRenderTargetView(), INT2( width, width ),
@@ -5508,7 +5508,7 @@ void D3D11GraphicsEngine::GetBackbufferData( byte** data, int& pixelsize ) {
     texDesc.ArraySize = 1;
     texDesc.BindFlags = 0;
     texDesc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
-    texDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+    texDesc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
     texDesc.Width = width;  // Gothic transforms the backbufferdata for
                             // savegamethumbs to 256x256-pictures anyways
     texDesc.Height = width;
@@ -6267,7 +6267,7 @@ void D3D11GraphicsEngine::SaveScreenshot() {
 
     // Buffer for scaling down the image
     auto rt = std::make_unique<RenderToTextureBuffer>(
-        GetDevice().Get(), Resolution.x, Resolution.y, DXGI_FORMAT_R8G8B8A8_UNORM );
+        GetDevice().Get(), Resolution.x, Resolution.y, DXGI_FORMAT_B8G8R8A8_UNORM );
 
     // Downscale to 256x256
     PfxRenderer->CopyTextureToRTV( HDRBackBuffer->GetShaderResView(), rt->GetRenderTargetView() );
@@ -6276,7 +6276,7 @@ void D3D11GraphicsEngine::SaveScreenshot() {
     texDesc.ArraySize = 1;
     texDesc.BindFlags = 0;
     texDesc.CPUAccessFlags = 0;
-    texDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+    texDesc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
     texDesc.Width = Resolution.x;   // must be same as backbuffer
     texDesc.Height = Resolution.y;  // must be same as backbuffer
     texDesc.MipLevels = 1;

--- a/D3D11Engine/D3D11PFX_SMAA.cpp
+++ b/D3D11Engine/D3D11PFX_SMAA.cpp
@@ -193,10 +193,10 @@ void D3D11PFX_SMAA::OnResize( const INT2& size ) {
 	HRESULT hr = S_OK;
 
 	// Create Edges- and Blend-Textures
-	EdgesTex = new RenderToTextureBuffer( engine->GetDevice().Get(), size.x, size.y, DXGI_FORMAT_R8G8B8A8_UNORM, &hr );
+	EdgesTex = new RenderToTextureBuffer( engine->GetDevice().Get(), size.x, size.y, DXGI_FORMAT_B8G8R8A8_UNORM, &hr );
 	LE( hr );
 
-	BlendTex = new RenderToTextureBuffer( engine->GetDevice().Get(), size.x, size.y, DXGI_FORMAT_R8G8B8A8_UNORM, &hr );
+	BlendTex = new RenderToTextureBuffer( engine->GetDevice().Get(), size.x, size.y, DXGI_FORMAT_B8G8R8A8_UNORM, &hr );
 	LE( hr );
 
 	std::vector<D3D_SHADER_MACRO> Makros;

--- a/D3D11Engine/D3D11Texture.cpp
+++ b/D3D11Engine/D3D11Texture.cpp
@@ -195,7 +195,7 @@ XRESULT D3D11Texture::CreateThumbnail() {
 
     // Create texture
     CD3D11_TEXTURE2D_DESC textureDesc(
-        DXGI_FORMAT_R8G8B8A8_UNORM,
+        DXGI_FORMAT_B8G8R8A8_UNORM,
         256,
         256,
         1,
@@ -241,7 +241,7 @@ XRESULT D3D11Texture::GenerateMipMaps() {
     D3D11GraphicsEngineBase* engine = reinterpret_cast<D3D11GraphicsEngineBase*>(Engine::GraphicsEngine);
 
     std::unique_ptr<RenderToTextureBuffer> b = std::make_unique<RenderToTextureBuffer>( engine->GetDevice().Get(), TextureSize.x, TextureSize.y,
-        DXGI_FORMAT_R8G8B8A8_UNORM, nullptr, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_UNKNOWN, MipMapCount );
+        DXGI_FORMAT_B8G8R8A8_UNORM, nullptr, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_UNKNOWN, MipMapCount );
 
     // Copy the main image
     engine->GetContext()->CopySubresourceRegion( b->GetTexture().Get(), 0, 0, 0, 0, Texture.Get(), 0, nullptr );

--- a/D3D11Engine/D3D11Texture.h
+++ b/D3D11Engine/D3D11Texture.h
@@ -8,6 +8,7 @@ public:
 
     /** Layec out for DXGI */
     enum ETextureFormat {
+        TF_B8G8R8A8 = DXGI_FORMAT_B8G8R8A8_UNORM,
         TF_R8G8B8A8 = DXGI_FORMAT_R8G8B8A8_UNORM,
         TF_DXT1 = DXGI_FORMAT_BC1_UNORM,
         TF_DXT3 = DXGI_FORMAT_BC2_UNORM,

--- a/D3D11Engine/D3D7/Conversions.h
+++ b/D3D11Engine/D3D7/Conversions.h
@@ -33,9 +33,9 @@ static void Convert565to8888(unsigned char* dst, unsigned char* src, UINT realDa
 		unsigned char greenComponent = ((pixel_data >> 5) & 63) << 2;
 		unsigned char blueComponent = ((pixel_data >> 11) & 31) << 3;
 
-		dst[4 * i + 2] = redComponent;
+		dst[4 * i + 2] = blueComponent;
 		dst[4 * i + 1] = greenComponent;
-		dst[4 * i + 0] = blueComponent;
+		dst[4 * i + 0] = redComponent;
 		dst[4 * i + 3] = 255;
 	}
 }
@@ -53,9 +53,9 @@ static void Convert1555to8888(unsigned char* dst, unsigned char* src, UINT realD
 		unsigned char blueComponent = ((pixel_data >> 10) & 31) << 3;
 		unsigned char alphaComponent = (pixel_data >> 15) * 0xFF;
 
-		dst[4 * i + 2] = redComponent;
+		dst[4 * i + 2] = blueComponent;
 		dst[4 * i + 1] = greenComponent;
-		dst[4 * i + 0] = blueComponent;
+		dst[4 * i + 0] = redComponent;
 		dst[4 * i + 3] = alphaComponent;
 	}
 }
@@ -73,9 +73,9 @@ static void Convert4444to8888(unsigned char* dst, unsigned char* src, UINT realD
 		unsigned char blueComponent = ((pixel_data >> 8) & 15) << 4;
 		unsigned char alphaComponent = ((pixel_data >> 12) & 15) << 4;
 
-		dst[4 * i + 2] = redComponent;
+		dst[4 * i + 2] = blueComponent;
 		dst[4 * i + 1] = greenComponent;
-		dst[4 * i + 0] = blueComponent;
+		dst[4 * i + 0] = redComponent;
 		dst[4 * i + 3] = alphaComponent;
 	}
 }

--- a/D3D11Engine/D3D7/MyDirectDraw.h
+++ b/D3D11Engine/D3D7/MyDirectDraw.h
@@ -200,7 +200,7 @@ public:
 				break;
 			}
 		} else {
-			fmt = DXGI_FORMAT_R8G8B8A8_UNORM;
+			fmt = DXGI_FORMAT_B8G8R8A8_UNORM;
 			bpp = 32;
 		}
 

--- a/D3D11Engine/D3D7/MyDirectDrawSurface7.cpp
+++ b/D3D11Engine/D3D7/MyDirectDrawSurface7.cpp
@@ -535,15 +535,15 @@ HRESULT MyDirectDrawSurface7::SetSurfaceDesc( LPDDSURFACEDESC2 lpDDSurfaceDesc, 
     int bpp = redBits + greenBits + blueBits + alphaBits;
 
     // Find out format
-    D3D11Texture::ETextureFormat format = D3D11Texture::ETextureFormat::TF_R8G8B8A8;
+    D3D11Texture::ETextureFormat format = D3D11Texture::ETextureFormat::TF_B8G8R8A8;
     switch ( bpp ) {
     case 16:
-        format = D3D11Texture::ETextureFormat::TF_R8G8B8A8;
+        format = D3D11Texture::ETextureFormat::TF_B8G8R8A8;
         break;
 
     case 24:
     case 32:
-        format = D3D11Texture::ETextureFormat::TF_R8G8B8A8;
+        format = D3D11Texture::ETextureFormat::TF_B8G8R8A8;
         break;
 
     case 0:

--- a/D3D11Engine/GOcean.cpp
+++ b/D3D11Engine/GOcean.cpp
@@ -136,7 +136,7 @@ void GOcean::CreateFresnelMap( Microsoft::WRL::ComPtr<ID3D11Device1> pd3dDevice 
     tex_desc.Width = FRESNEL_TEX_SIZE;
     tex_desc.MipLevels = 1;
     tex_desc.ArraySize = 1;
-    tex_desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+    tex_desc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
     tex_desc.Usage = D3D11_USAGE_IMMUTABLE;
     tex_desc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
     tex_desc.CPUAccessFlags = 0;
@@ -154,7 +154,7 @@ void GOcean::CreateFresnelMap( Microsoft::WRL::ComPtr<ID3D11Device1> pd3dDevice 
 
     // Create shader resource
     D3D11_SHADER_RESOURCE_VIEW_DESC srv_desc = {};
-    srv_desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+    srv_desc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
     srv_desc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE1D;
     srv_desc.Texture1D.MipLevels = 1;
     srv_desc.Texture1D.MostDetailedMip = 0;

--- a/D3D11Engine/SV_GMeshInfoView.cpp
+++ b/D3D11Engine/SV_GMeshInfoView.cpp
@@ -223,7 +223,7 @@ void SV_GMeshInfoView::SetRect( const D2D1_RECT_F& rect ) {
 
 	// Create new RT
 	delete RT;
-	RT = new RenderToTextureBuffer( g->GetDevice().Get(), std::max<UINT>( 8, GetSize().width ), std::max<UINT>( 8, GetSize().height ), DXGI_FORMAT_R8G8B8A8_UNORM );
+	RT = new RenderToTextureBuffer( g->GetDevice().Get(), std::max<UINT>( 8, GetSize().width ), std::max<UINT>( 8, GetSize().height ), DXGI_FORMAT_B8G8R8A8_UNORM );
 
 	delete DS;
 	DS = new RenderToDepthStencilBuffer( g->GetDevice().Get(), std::max<UINT>( 8, GetSize().width ), std::max<UINT>( 8, GetSize().height ), DXGI_FORMAT_R32_TYPELESS, nullptr, DXGI_FORMAT_D32_FLOAT, DXGI_FORMAT_R32_FLOAT );

--- a/D3D11Engine/SV_Panel.cpp
+++ b/D3D11Engine/SV_Panel.cpp
@@ -105,7 +105,7 @@ HRESULT SV_Panel::SetD3D11TextureAsImage( ID3D11Texture2D* texture, INT2 size ) 
     // Since D2D can't load DXTn-Textures on Windows 7, we copy it over to a smaller texture here in d3d11
 
     // Create texture
-    CD3D11_TEXTURE2D_DESC textureDesc( DXGI_FORMAT_R8G8B8A8_UNORM, size.x, size.y, 1, 1, 0, D3D11_USAGE_STAGING, D3D11_CPU_ACCESS_READ, 1, 0, 0 );
+    CD3D11_TEXTURE2D_DESC textureDesc( DXGI_FORMAT_B8G8R8A8_UNORM, size.x, size.y, 1, 1, 0, D3D11_USAGE_STAGING, D3D11_CPU_ACCESS_READ, 1, 0, 0 );
 
     ComPtr<ID3D11Texture2D> staging;
     LE( engine->GetDevice()->CreateTexture2D( &textureDesc, nullptr, staging.ReleaseAndGetAddressOf() ) );
@@ -113,7 +113,7 @@ HRESULT SV_Panel::SetD3D11TextureAsImage( ID3D11Texture2D* texture, INT2 size ) 
     engine->GetContext()->CopyResource( staging.Get(), texture );
 
     D2D1_BITMAP_PROPERTIES properties;
-    properties = D2D1::BitmapProperties( D2D1::PixelFormat( DXGI_FORMAT_R8G8B8A8_UNORM, D2D1_ALPHA_MODE_IGNORE ), 0, 0 );
+    properties = D2D1::BitmapProperties( D2D1::PixelFormat( DXGI_FORMAT_B8G8R8A8_UNORM, D2D1_ALPHA_MODE_IGNORE ), 0, 0 );
 
     // Get data out
     D3D11_MAPPED_SUBRESOURCE mapped;

--- a/D3D11Engine/zBinkPlayer.cpp
+++ b/D3D11Engine/zBinkPlayer.cpp
@@ -260,23 +260,16 @@ int __fastcall BinkPlayerPlayFrame(DWORD BinkPlayer)
 					ddsd.ddpfPixelFormat.dwSize = sizeof(ddsd.ddpfPixelFormat);
 					ddsd.ddpfPixelFormat.dwFlags = DDPF_RGB | DDPF_ALPHAPIXELS;
 					ddsd.ddpfPixelFormat.dwRGBBitCount = 32;
-					ddsd.ddpfPixelFormat.dwRBitMask = 0x000000FF;
+					ddsd.ddpfPixelFormat.dwRBitMask = 0x00FF0000;
 					ddsd.ddpfPixelFormat.dwGBitMask = 0x0000FF00;
-					ddsd.ddpfPixelFormat.dwBBitMask = 0x00FF0000;
+					ddsd.ddpfPixelFormat.dwBBitMask = 0x000000FF;
 					ddsd.ddpfPixelFormat.dwRGBAlphaBitMask = 0xFF000000;
+                    video->useBGRA = true;
 					HRESULT hr = (*reinterpret_cast<LPDIRECTDRAW7*>(GothicMemoryLocations::zCRndD3D::DDRAW7))->CreateSurface(&ddsd, &video->texture, nullptr);
 					if(FAILED(hr))
 					{
-						video->useBGRA = true;
-						ddsd.ddpfPixelFormat.dwRBitMask = 0x00FF0000;
-						ddsd.ddpfPixelFormat.dwGBitMask = 0x0000FF00;
-						ddsd.ddpfPixelFormat.dwBBitMask = 0x000000FF;
-						hr = (*reinterpret_cast<LPDIRECTDRAW7*>(GothicMemoryLocations::zCRndD3D::DDRAW7))->CreateSurface(&ddsd, &video->texture, nullptr);
-						if(FAILED(hr))
-						{
-							*reinterpret_cast<int*>(BinkPlayer + GothicMemoryLocations::zCBinkPlayer::Offset_IsPlaying) = 0;
-							return 0;
-						}
+                        *reinterpret_cast<int*>(BinkPlayer + GothicMemoryLocations::zCBinkPlayer::Offset_IsPlaying) = 0;
+                        return 0;
 					}
 
 					video->scaleTU = 1.0f / ddsd.dwWidth;


### PR DESCRIPTION
This change is required to preserve compatibility with original renderer (dx7). For instance any mod/plugin that adds any logic that uses game texture buffers needs to flip colors manually and that is an expensive operation performed every frame.

With this change any mod/plugin does not have to make any logic checks dependent on used dx renderer, instead the code will be the same for both versions.