### PR TITLE
Remove unnecessary if statement in DX7 DrawPrimitive.

### DIFF
--- a/D3D11Engine/D3D7/MyDirect3DDevice7.h
+++ b/D3D11Engine/D3D7/MyDirect3DDevice7.h
@@ -482,10 +482,6 @@ public:
 
 	HRESULT STDMETHODCALLTYPE DrawPrimitive( D3DPRIMITIVETYPE dptPrimitiveType, DWORD dwVertexTypeDesc, LPVOID lpvVertices, DWORD dwVertexCount, DWORD dwFlags ) {
 		DebugWrite( "MyDirect3DDevice7::DrawPrimitive" );
-		if ( dptPrimitiveType != D3DPT_TRIANGLEFAN )
-		{
-			return S_OK;
-		}
 
 		// Convert them into ExVertices
 		static std::vector<ExVertexStruct> exv;


### PR DESCRIPTION
Removed unnecessary if statement in `IDirect3DDevice7::DrawPrimitive`, so modders can use more primatives like triangle lists.