### PR TITLE
Added GDX_SaveRendererSettings to Ikarus bindings

### DIFF
--- a/D3D11Engine/IkarusBindings.cpp
+++ b/D3D11Engine/IkarusBindings.cpp
@@ -190,4 +190,10 @@ extern "C"
         structSize = sizeof( Engine::GAPI->GetRendererState().RendererSettings );
         return &Engine::GAPI->GetRendererState().RendererSettings;
     }
+
+    /** Save Renderer Settings */
+    __declspec(dllexport) void __cdecl GDX_SaveRendererSettings() {
+        Engine::GAPI->SaveRendererWorldSettings( Engine::GAPI->GetRendererState().RendererSettings );
+        Engine::GAPI->SaveMenuSettings( MENU_SETTINGS_FILE );
+    }
 };


### PR DESCRIPTION
Ikarus bindings are also used by G2O project (in order to read/write renderer settings) and there is a lack of save functionality