### PR TITLE
Rain effects slider with new "Simple" mode (no shiny ground)

### DIFF
--- a/D3D11Engine/ConstantBufferStructs.h
+++ b/D3D11Engine/ConstantBufferStructs.h
@@ -300,5 +300,8 @@ struct AtmosphereConstantBuffer {
 
     float3 AC_SpherePosition;
     float AC_RainFXWeight;
+
+    int AC_RainEffectsQuality;
+    float3 AC_Pad;
 };
 #pragma pack (pop)

--- a/D3D11Engine/D2DSettingsDialog.cpp
+++ b/D3D11Engine/D2DSettingsDialog.cpp
@@ -14,7 +14,7 @@
 #include <locale>
 
 constexpr int UI_WIN_SIZE_X = 540;
-constexpr int UI_WIN_SIZE_Y = 410;
+constexpr int UI_WIN_SIZE_Y = 440;
 
 #if defined(BUILD_GOTHIC_1_08k) && !defined(BUILD_1_12F)
 extern bool haveWindAnimations;
@@ -612,20 +612,28 @@ XRESULT D2DSettingsDialog::InitControls() {
     rainCheckbox->SetChecked( Engine::GAPI->GetRendererState().RendererSettings.EnableRain );
     rainCheckbox->SetPosition( D2D1::Point2F( 170 + 160 + 30, rainCheckbox->GetPosition().y ) );
 
-    SV_Checkbox* rainEffectsCheckbox = new SV_Checkbox( MainView, MainPanel );
-    rainEffectsCheckbox->SetPositionAndSize( D2D1::Point2F( 10, 10 ), D2D1::SizeF( 160, 20 ) );
-    rainEffectsCheckbox->AlignUnder( rainCheckbox, 5 );
+    // Rain effects quality slider
+    SV_Label* rainEffectsLabel = new SV_Label( MainView, MainPanel );
+    rainEffectsLabel->SetPositionAndSize( D2D1::Point2F( 10, 10 ), D2D1::SizeF( 150, 12 ) );
+    rainEffectsLabel->AlignUnder( rainCheckbox, 8 );
     switch ( userLanguage ) {
-    case LANGUAGE_POLISH: rainEffectsCheckbox->SetCaption( L"Włącz Efekty Deszczu" ); break;
-    default: rainEffectsCheckbox->SetCaption( L"Enable Rain Effects" ); break;
+    case LANGUAGE_POLISH: rainEffectsLabel->SetCaption( L"Jakość Efektów Deszczu:" ); break;
+    default: rainEffectsLabel->SetCaption( L"Rain Effects Quality:" ); break;
     }
-    rainEffectsCheckbox->SetDataToUpdate( &Engine::GAPI->GetRendererState().RendererSettings.EnableRainEffects );
-    rainEffectsCheckbox->SetChecked( Engine::GAPI->GetRendererState().RendererSettings.EnableRainEffects );
+
+    SV_Slider* rainEffectsSlider = new SV_Slider( MainView, MainPanel );
+    rainEffectsSlider->SetPositionAndSize( D2D1::Point2F( 10, 22 ), D2D1::SizeF( 150, 15 ) );
+    rainEffectsSlider->AlignUnder( rainEffectsLabel, 5 );
+    rainEffectsSlider->SetDataToUpdate( reinterpret_cast<int*>(&Engine::GAPI->GetRendererState().RendererSettings.RainEffectsQuality) );
+    rainEffectsSlider->SetIsIntegralSlider( true );
+    rainEffectsSlider->SetMinMax( 0.0f, GothicRendererSettings::ERainEffectsQuality::RAIN_QUALITY_ADVANCED );
+    rainEffectsSlider->SetDisplayValues( { "Disabled", "Simple", "Advanced" } );
+    rainEffectsSlider->SetValue( static_cast<float>(Engine::GAPI->GetRendererState().RendererSettings.RainEffectsQuality) );
 
     InitialSettings.EnableWaterAnimation = Engine::GAPI->GetRendererState().RendererSettings.EnableWaterAnimation;
     SV_Checkbox* waterWaveCheckbox = new SV_Checkbox( MainView, MainPanel );
     waterWaveCheckbox->SetPositionAndSize( D2D1::Point2F( 10, 10 ), D2D1::SizeF( 160, 20 ) );
-    waterWaveCheckbox->AlignUnder( rainEffectsCheckbox, 5 );
+    waterWaveCheckbox->AlignUnder( rainEffectsSlider, 5 );
     switch ( userLanguage ) {
     case LANGUAGE_POLISH: waterWaveCheckbox->SetCaption( L"Włącz Efekty Fali [*]" ); break;
     default: waterWaveCheckbox->SetCaption( L"Enable Water Waves [*]" ); break;

--- a/D3D11Engine/GSky.cpp
+++ b/D3D11Engine/GSky.cpp
@@ -291,12 +291,16 @@ XRESULT GSky::RenderSky() {
     AtmosphereCB.AC_g = Atmosphere.G;
     AtmosphereCB.AC_Wavelength = Atmosphere.WaveLengths;
     AtmosphereCB.AC_SpherePosition = sp;
-    if ( !Engine::GAPI->GetRendererState().RendererSettings.EnableRainEffects ) {
+    // Handle rain effects based on quality setting
+    int rainEffectsQuality = Engine::GAPI->GetRendererState().RendererSettings.RainEffectsQuality;
+    if ( rainEffectsQuality == GothicRendererSettings::RAIN_QUALITY_DISABLED ) {
         AtmosphereCB.AC_SceneWettness = 0.f;
     } else {
+        // RAIN_QUALITY_SIMPLE and RAIN_QUALITY_ADVANCED - shader handles the 0.25 multiplier for Simple
         AtmosphereCB.AC_SceneWettness = Engine::GAPI->GetSceneWetness();
     }
     AtmosphereCB.AC_RainFXWeight = Engine::GAPI->GetRainFXWeight();
+    AtmosphereCB.AC_RainEffectsQuality = rainEffectsQuality;
 
     //Engine::GraphicsEngine->DrawSky();
 

--- a/D3D11Engine/GothicAPI.cpp
+++ b/D3D11Engine/GothicAPI.cpp
@@ -4530,7 +4530,7 @@ XRESULT GothicAPI::SaveMenuSettings( const std::string& file ) {
     WritePrivateProfileStringA( "Display", "StretchWindow", std::to_string( s.StretchWindow ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "Display", "UIScale", std::to_string( s.GothicUIScale ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "Display", "Rain", std::to_string( s.EnableRain ? TRUE : FALSE ).c_str(), ini.c_str() );
-    WritePrivateProfileStringA( "Display", "RainEffects", std::to_string( s.EnableRainEffects ? TRUE : FALSE ).c_str(), ini.c_str() );
+    WritePrivateProfileStringA( "Display", "RainEffectsQuality", std::to_string( s.RainEffectsQuality ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "Display", "LimitLightIntesity", std::to_string( s.LimitLightIntesity ? TRUE : FALSE ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "Display", "WindQuality", std::to_string( s.WindQuality ).c_str(), ini.c_str() );
     WritePrivateProfileStringA( "Display", "WindStrength", std::to_string( s.GlobalWindStrength ).c_str(), ini.c_str() );
@@ -4648,7 +4648,13 @@ XRESULT GothicAPI::LoadMenuSettings( const std::string& file ) {
         s.StretchWindow = GetPrivateProfileBoolA( "Display", "StretchWindow", false, ini );
         s.GothicUIScale = GetPrivateProfileFloatA( "Display", "UIScale", 1.0f, ini );
         s.EnableRain = GetPrivateProfileBoolA( "Display", "Rain", true, ini );
-        s.EnableRainEffects = GetPrivateProfileBoolA( "Display", "RainEffects", true, ini );
+        // Load RainEffectsQuality with backward compatibility (old bool RainEffects: true -> ADVANCED, false -> DISABLED)
+        s.RainEffectsQuality = GetPrivateProfileIntA( "Display", "RainEffectsQuality", -1, ini.c_str() );
+        if ( s.RainEffectsQuality == -1 ) {
+            // Fallback to old setting
+            bool oldRainEffects = GetPrivateProfileBoolA( "Display", "RainEffects", true, ini );
+            s.RainEffectsQuality = oldRainEffects ? GothicRendererSettings::RAIN_QUALITY_ADVANCED : GothicRendererSettings::RAIN_QUALITY_DISABLED;
+        }
         s.LimitLightIntesity = GetPrivateProfileBoolA( "Display", "LimitLightIntesity", false, ini );
         s.WindQuality = GetPrivateProfileIntA( "Display", "WindQuality", 0, ini.c_str() );
         s.GlobalWindStrength = GetPrivateProfileFloatA( "Display", "WindStrength", 1.0f, ini );

--- a/D3D11Engine/GothicGraphicsState.h
+++ b/D3D11Engine/GothicGraphicsState.h
@@ -516,6 +516,11 @@ struct GothicRendererSettings {
         WIND_QUALITY_NONE = 0,
         WIND_QUALITY_ADVANCED,
     };
+    enum ERainEffectsQuality {
+        RAIN_QUALITY_DISABLED = 0,
+        RAIN_QUALITY_SIMPLE,
+        RAIN_QUALITY_ADVANCED,
+    };
 
 
     /** Sets the default values for this struct */
@@ -647,7 +652,7 @@ struct GothicRendererSettings {
         RainFogDensity = 0.00050f;
 
         EnableRain = true;
-        EnableRainEffects = true;
+        RainEffectsQuality = RAIN_QUALITY_ADVANCED;
 
         GodRayDecay = 0.97f;
         GodRayWeight = 0.85f;
@@ -817,7 +822,7 @@ struct GothicRendererSettings {
     float RainFogDensity;
 
     bool EnableRain;
-    bool EnableRainEffects;
+    int RainEffectsQuality;
 
     bool LimitLightIntesity;
     bool AllowNormalmaps;

--- a/D3D11Engine/Shaders/AtmosphericScattering.h
+++ b/D3D11Engine/Shaders/AtmosphericScattering.h
@@ -32,6 +32,9 @@ cbuffer Atmosphere : register( b1 )
 
 	float3 AC_SpherePosition;
 	float AC_RainFXWeight;
+
+	int AC_RainEffectsQuality;
+	float3 AC_Pad;
 };
 
 // The scale equation calculated by Vernier's Graphical Analysis

--- a/D3D11Engine/Shaders/PS_DS_AtmosphericScattering.hlsl
+++ b/D3D11Engine/Shaders/PS_DS_AtmosphericScattering.hlsl
@@ -242,6 +242,12 @@ void ApplySceneWettness(float3 wsPosition, float3 vsPosition, float3 vsDir, inou
 	ApplyRainNormalDeformation(nrm, wsPosition, diffuse.rgb, wsNormal);
 	pixelWettnes *= 1 - pow(saturate(dot(wsNormal, float3(0,-1,0))), 4.0f);
 	
+	// Apply quality multiplier: Simple = disabled, Advanced = full
+	if (AC_RainEffectsQuality == 1) // RAIN_QUALITY_SIMPLE
+	{
+		pixelWettnes = 0; // Completely disable wet surface effects for Simple mode
+	}
+	
 	vsNormal = lerp(vsNormal, nrm, AC_RainFXWeight * pixelWettnes * 0.5f); // Only apply deformation if it's actually raining
 	
 	// Get fresnel-effect


### PR DESCRIPTION
Replaced the rain checkbox with a slider. "Advanced" is the old "on", "Disabled" is old "off", and the new "Simple" mode disables pixelWettnes, the shiny ground effect that a lot of people complained about